### PR TITLE
Restrict coverage filter

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -75,7 +75,7 @@ Task("Test")
     OpenCover(
         tool => tool.DotNetCoreVSTest("**/bin/**/*Tests.dll"),
         new FilePath("./coverage.xml"),
-        new OpenCoverSettings { ReturnTargetCodeOffset = 0, OldStyle = true }.WithFilter("+[*LevelUp*]*").WithFilter("-[*Tests*]*")
+        new OpenCoverSettings { ReturnTargetCodeOffset = 0, OldStyle = true }.WithFilter("+[*LevelUp*]LevelUp*").WithFilter("-[*Tests*]*")
     );
 
      if(AppVeyor.IsRunningOnAppVeyor)


### PR DESCRIPTION
[POS-675](https://levelup.atlassian.net/browse/POS-675)

Generated code (such as gitversion information) skews coverage reports. This narrows coverage filter to only include classes in a LevelUp* namespace in a LevelUp* assembly. As long as our assemblies/namespaces are consistently named this filter should be applicable in all repos.