### PR TITLE
[INSTORE-625] Convert MSTest to NUnit.

### DIFF
--- a/LevelUp.Pos.ProposedOrders.Tests/CalculateAdjustedExemptionTests.cs
+++ b/LevelUp.Pos.ProposedOrders.Tests/CalculateAdjustedExemptionTests.cs
@@ -1,127 +1,129 @@
-﻿using System;
-using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using NUnit.Framework;
+using System;
 
 namespace LevelUp.Pos.ProposedOrders.Tests
 {
-    [TestClass]
+    [TestFixture]
     public class CalculateAdjustedExemptionTests
     {
 
-        [TestMethod]
-        public void PaymentZero_ReturnsZero()
+        [Test]
+        [TestCase(500, 0)]
+        [TestCase(1, 0)]
+        public void CalculateAdjustedExemptionAmount_PaymentZero_ReturnsZero(
+            int exemptionAmount, int calculatedExemptionAmount)
         {
+            // Arrange
             var checkData = new CheckData
             {
                 OutstandingAmount = 1000,
                 TaxAmount = 0,
-                ExemptionAmount = 500,
+                ExemptionAmount = exemptionAmount,
                 PaymentAmount = 0
             };
 
-            ProposedOrderCalculator.CalculateAdjustedExemptionAmount(checkData)
-                .Should().Be(0);
+            // Act
+            var result = ProposedOrderCalculator.CalculateAdjustedExemptionAmount(checkData);
 
-            checkData.ExemptionAmount = 1;
-            ProposedOrderCalculator.CalculateAdjustedExemptionAmount(checkData)
-                .Should().Be(0);
+            // Assert
+            Assert.AreEqual(calculatedExemptionAmount, result);
         }
 
-        [TestMethod]
-        public void PaymentLessThanNonExempt_ReturnsZero()
+
+        [Test]
+        [TestCase(500, 0)]
+        [TestCase(400, 0)]
+        [TestCase(499, 0)]
+        public void CalculateAdjustedExemptionAmount_PaymentLessThanNonExempt_ReturnsZero(
+            int exemptionAmount, int calculatedExemptionAmount)
         {
+            // Arrange
             var checkData = new CheckData
             {
                 OutstandingAmount = 1000,
                 TaxAmount = 0,
-                ExemptionAmount = 500,
+                ExemptionAmount = exemptionAmount,
                 PaymentAmount = 1
             };
 
-            ProposedOrderCalculator.CalculateAdjustedExemptionAmount(checkData)
-                .Should().Be(0);
+            // Act
+            var result = ProposedOrderCalculator.CalculateAdjustedExemptionAmount(checkData);
 
-            checkData.PaymentAmount = 400;
-            ProposedOrderCalculator.CalculateAdjustedExemptionAmount(checkData)
-                .Should().Be(0);
-
-            checkData.PaymentAmount = 499;
-            ProposedOrderCalculator.CalculateAdjustedExemptionAmount(checkData)
-                .Should().Be(0);
+            // Assert
+            Assert.AreEqual(calculatedExemptionAmount, result);
         }
 
-        [TestMethod]
-        public void PaymentGreaterThanNonExemptButLessThanPreTaxSubtotal_ReturnsPartialAmount()
+        [Test]
+        [TestCase(801, 1)]
+        [TestCase(900, 100)]
+        [TestCase(999, 199)]
+        public void CalculateAdjustedExemptionAmount_PaymentGreaterThanNonExemptButLessThanPreTaxSubtotal_ReturnsPartialAmount(
+            int paymentAmount, int calculatedExemptionAmount)
         {
             var checkData = new CheckData
             {
                 OutstandingAmount = 1000,
                 TaxAmount = 0,
                 ExemptionAmount = 200,
-                PaymentAmount = 801
+                PaymentAmount = paymentAmount
             };
-            // In this case, the partial amount should be payment - 800
 
-            ProposedOrderCalculator.CalculateAdjustedExemptionAmount(checkData)
-                .Should().Be(1);
+            // Act
+            var result = ProposedOrderCalculator.CalculateAdjustedExemptionAmount(checkData);
 
-            checkData.PaymentAmount = 900;
-            ProposedOrderCalculator.CalculateAdjustedExemptionAmount(checkData)
-                .Should().Be(100);
-
-            checkData.PaymentAmount = 999;
-            ProposedOrderCalculator.CalculateAdjustedExemptionAmount(checkData)
-                .Should().Be(199);
+            // Assert
+            Assert.AreEqual(calculatedExemptionAmount, result);
         }
 
-        [TestMethod]
-        public void PaymentAmountGreaterThanOrEqualToPreTaxSubtotal_ReturnsExemptionUnchanged()
+        [Test]
+        [TestCase(1000, 500)]
+        [TestCase(1100, 500)]
+        public void CalculateAdjustedExemptionAmount_PaymentAmountGreaterThanOrEqualToPreTaxSubtotal_ReturnsExemptionUnchanged(
+            int paymentAmount, int calculatedExemptionAmount)
         {
+            // Arrange
             var checkData = new CheckData
             {
                 OutstandingAmount = 1000,
                 TaxAmount = 0,
                 ExemptionAmount = 500,
-                PaymentAmount = 1000
+                PaymentAmount = paymentAmount
             };
-            // PreTaxSubtotal = 1000
 
-            // Payment = PreTaxSubtotal
-            ProposedOrderCalculator.CalculateAdjustedExemptionAmount(checkData)
-                .Should().Be(500);
+            // Act
+            var result = ProposedOrderCalculator.CalculateAdjustedExemptionAmount(checkData);
 
-            // Payment > PreTaxSubtotal
-            checkData.PaymentAmount = 1100;
-            ProposedOrderCalculator.CalculateAdjustedExemptionAmount(checkData)
-                .Should().Be(500);
+            // Assert
+            Assert.AreEqual(calculatedExemptionAmount, result);
         }
 
-        [TestMethod]
-        public void ExemptEqualsPreTaxSubtotal_PaymentLessThanPreTaxSubtotal_ReturnPaymentAmount()
+        [Test]
+        [TestCase(1, 1)]
+        [TestCase(500, 500)]
+        [TestCase(999, 999)]
+        public void CalculateAdjustedExemptionAmount_ExemptEqualToSubtotalandPaymentLessThanSubtotal_ReturnsPaymentAmount(
+            int paymentAmount, int calculatedExemptedAmount)
         {
+            // Arrange
             var checkData = new CheckData
             {
                 OutstandingAmount = 1000,
                 TaxAmount = 0,
                 ExemptionAmount = 1000,
-                PaymentAmount = 1
+                PaymentAmount = paymentAmount
             };
 
-            ProposedOrderCalculator.CalculateAdjustedExemptionAmount(checkData)
-                .Should().Be(1);
+            // Act
+            var result = ProposedOrderCalculator.CalculateAdjustedExemptionAmount(checkData);
 
-            checkData.PaymentAmount = 500;
-            ProposedOrderCalculator.CalculateAdjustedExemptionAmount(checkData)
-                .Should().Be(500);
-
-            checkData.PaymentAmount = 999;
-            ProposedOrderCalculator.CalculateAdjustedExemptionAmount(checkData)
-                .Should().Be(999);
+            // Assert
+            Assert.AreEqual(calculatedExemptedAmount, result);
         }
 
-        [TestMethod]
-        public void ExemptAmountGreaterThanPreTaxOutstanding_ThrowsException()
+        [Test]
+        public void CalculateAdjustedExemptionAmount_ExemptAmountGreaterThanPreTaxOutstanding_ThrowsException()
         {
+            // Arrange
             var checkData = new CheckData
             {
                 OutstandingAmount = 1000,
@@ -130,8 +132,11 @@ namespace LevelUp.Pos.ProposedOrders.Tests
                 PaymentAmount = 500
             };
 
-            Action action = () => ProposedOrderCalculator.CalculateAdjustedExemptionAmount(checkData);
-            action.Should().Throw<Exception>();
+            // Act
+            TestDelegate action = () => ProposedOrderCalculator.CalculateAdjustedExemptionAmount(checkData);
+
+            // Assert
+            Assert.Throws<Exception>(action);
         }
     }
 }

--- a/LevelUp.Pos.ProposedOrders.Tests/CalculateAdjustedTaxAmountTests.cs
+++ b/LevelUp.Pos.ProposedOrders.Tests/CalculateAdjustedTaxAmountTests.cs
@@ -1,57 +1,63 @@
 ﻿using System;
-using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NUnit.Framework;
 
 namespace LevelUp.Pos.ProposedOrders.Tests
 {
-    [TestClass]
+    [TestFixture]
     public class CalculateAdjustedTaxAmountTests
     {
-        [TestMethod]
-        public void PaymentLessThanPreTaxSubtotal_ReturnZero()
+        [Test]
+        [TestCase(0, 0)]
+        [TestCase(799, 0)]
+        public void CalculateAdjustedTaxAmount_PaymentLessThanPreTaxSubtotal_ReturnZero(
+            int paymentAmount, int calculatedExemptionAmount)
         {
+            // Arrange
             var checkData = new CheckData
             {
                 OutstandingAmount = 1000,
                 ExemptionAmount = 0,
                 TaxAmount = 200,
-                PaymentAmount = 0
+                PaymentAmount = paymentAmount
             };
+            
+            // Act
+            var result = ProposedOrderCalculator.CalculateAdjustedTaxAmount(checkData);
 
-            ProposedOrderCalculator.CalculateAdjustedTaxAmount(checkData)
-                .Should().Be(0);
-
-            checkData.PaymentAmount = 799;
-            ProposedOrderCalculator.CalculateAdjustedTaxAmount(checkData)
-                .Should().Be(0);
+            // Assert
+            Assert.AreEqual(calculatedExemptionAmount, result);
         }
 
-        [TestMethod]
-        public void PaymentGreaterThanPreTaxSubtotalButLessThanOutstanding_ReturnTaxPaid()
+        [Test]
+        [TestCase(801, 1)]
+        [TestCase(900, 100)]
+        [TestCase(999, 199)]
+        public void CalculateAdjustedTaxAmount_PaymentGreaterThanPreTaxSubtotalButLessThanOutstanding_ReturnTaxPaid(
+            int paymentAmount, int calculatedExemptionAmount)
         {
+            // Arrange
             var checkData = new CheckData
             {
                 OutstandingAmount = 1000,
                 ExemptionAmount = 0,
                 TaxAmount = 200,
-                PaymentAmount = 801
+                PaymentAmount = paymentAmount
             };
 
-            ProposedOrderCalculator.CalculateAdjustedTaxAmount(checkData)
-                .Should().Be(1);
+            // Act
+            var result = ProposedOrderCalculator.CalculateAdjustedTaxAmount(checkData);
 
-            checkData.PaymentAmount = 900;
-            ProposedOrderCalculator.CalculateAdjustedTaxAmount(checkData)
-                .Should().Be(100);
-
-            checkData.PaymentAmount = 999;
-            ProposedOrderCalculator.CalculateAdjustedTaxAmount(checkData)
-                .Should().Be(199);
+            // Assert
+            Assert.AreEqual(calculatedExemptionAmount, result);
         }
 
-        [TestMethod]
-        public void PaymentGreaterThanOrEqualToOutstandingAmount_ReturnsTaxAmount()
+        [Test]
+        [TestCase(1000, 200)]
+        [TestCase(1200, 200)]
+        public void CalculateAdjustedTaxAmount_PaymentGreaterThanOrEqualToOutstandingAmount_ReturnsTaxAmount(
+            int paymentAmount, int calculatedExemptionAmount)
         {
+            // Arrange
             var checkData = new CheckData
             {
                 OutstandingAmount = 1000,
@@ -60,17 +66,17 @@ namespace LevelUp.Pos.ProposedOrders.Tests
                 PaymentAmount = 1000
             };
 
-            ProposedOrderCalculator.CalculateAdjustedTaxAmount(checkData)
-                .Should().Be(200);
+            // Act
+            var result = ProposedOrderCalculator.CalculateAdjustedTaxAmount(checkData);
 
-            checkData.PaymentAmount = 1200;
-            ProposedOrderCalculator.CalculateAdjustedTaxAmount(checkData)
-                .Should().Be(200);
+            // Assert
+            Assert.AreEqual(calculatedExemptionAmount, result);
         }
 
-        [TestMethod]
-        public void TaxGreaterThanOutstanding_ThrowsException()
+        [Test]
+        public void CalculateAdjustedTaxAmount_TaxGreaterThanOutstanding_ThrowsException()
         {
+            // Arrange
             var checkData = new CheckData
             {
                 OutstandingAmount = 1000,
@@ -79,8 +85,11 @@ namespace LevelUp.Pos.ProposedOrders.Tests
                 PaymentAmount = 500
             };
 
-            Action action = () => ProposedOrderCalculator.CalculateAdjustedTaxAmount(checkData);
-            action.Should().Throw<Exception>();
+            // Act
+            TestDelegate action = () => ProposedOrderCalculator.CalculateAdjustedTaxAmount(checkData);
+
+            // Assert
+            Assert.Throws<Exception>(action);
         }
     }
 }

--- a/LevelUp.Pos.ProposedOrders.Tests/CalculatorTests.cs
+++ b/LevelUp.Pos.ProposedOrders.Tests/CalculatorTests.cs
@@ -18,16 +18,15 @@
 #endregion
 
 using System;
-using FluentAssertions;
 using LevelUp.Pos.CheckCalculators.Tests.Data;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NUnit.Framework;
 
 namespace LevelUp.Pos.ProposedOrders.Tests
 {
-    [TestClass]
+    [TestFixture]
     public class CalculatorTests
     {
-        [TestMethod]
+        [Test]
         public void RunTestBattery()
         {
             RunTestArray(CalculatorTestData.TestBattery);
@@ -37,6 +36,7 @@ namespace LevelUp.Pos.ProposedOrders.Tests
         {
             for (int i = 0; i < values.GetLength(0); i++)
             {
+                // Arrange
                 int totalOutstandingAmount = values[i, 0];
                 int totalTaxAmount = values[i, 1];
                 int totalExemptionAmount = values[i, 2];
@@ -48,16 +48,18 @@ namespace LevelUp.Pos.ProposedOrders.Tests
 
                 AdjustedCheckValues expectedCheckValues =
                     new AdjustedCheckValues(expectedSpendAmount, expectedTaxAmount, expectedExemptionAmount);
-
+                
+                // Act
                 AdjustedCheckValues actualCheckValues = ProposedOrderCalculator.CalculateCreateProposedOrderValues(
                     totalOutstandingAmount,
                     totalTaxAmount,
                     totalExemptionAmount,
                     spendAmount);
 
-                actualCheckValues.Should().BeEquivalentTo(expectedCheckValues,
-                    "row={0}; Expected:{1}; Actual: {2}",
-                    i, expectedCheckValues, actualCheckValues, Environment.NewLine);
+                // Assert
+                Assert.AreEqual(expectedCheckValues.ExemptionAmount, actualCheckValues.ExemptionAmount);
+                Assert.AreEqual(expectedCheckValues.SpendAmount, actualCheckValues.SpendAmount);
+                Assert.AreEqual(expectedCheckValues.TaxAmount, actualCheckValues.TaxAmount);
             }
         }
     }

--- a/LevelUp.Pos.ProposedOrders.Tests/LevelUp.Pos.ProposedOrders.Tests.csproj
+++ b/LevelUp.Pos.ProposedOrders.Tests/LevelUp.Pos.ProposedOrders.Tests.csproj
@@ -7,10 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.4.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LevelUp.Pos.ProposedOrders.Tests/PointOfSaleTests.cs
+++ b/LevelUp.Pos.ProposedOrders.Tests/PointOfSaleTests.cs
@@ -1,19 +1,19 @@
-﻿using FluentAssertions;
-using LevelUp.Pos.ProposedOrders.Tests.Mocks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using LevelUp.Pos.ProposedOrders.Tests.Mocks;
+using NUnit.Framework;
 
 namespace LevelUp.Pos.ProposedOrders.Tests
 {
-    [TestClass]
+    [TestFixture]
     public class PointOfSaleTests
     {
         /// <summary>
         /// Simple test with (somewhat) arbitrary values that was added when a rounding error in the PointOfSale.cs
         /// class was discovered.
         /// </summary>
-        [TestMethod]
+        [Test]
         public void PointOfSaleTests_RoundingTest1()
         {
+            // Arrange
             PointOfSale pointOfSale = new PointOfSale(total: 1131, tax: 74);
 
             int exemptionAmount = 0;
@@ -22,23 +22,32 @@ namespace LevelUp.Pos.ProposedOrders.Tests
             // apply tender(s)
             pointOfSale.ApplyTender(0);
 
+            var expectedProposedOrderValues = new AdjustedCheckValues(
+                spendAmount: 1131, taxAmount: 74, exemptionAmount: 0);
+            
+            // Act
             // prepare Proposed Order call
             AdjustedCheckValues proposedOrderValues = ProposedOrderCalculator.CalculateCreateProposedOrderValues(
                 pointOfSale.TotalOutstandingAmount,
                 pointOfSale.TotalTaxAmount,
                 exemptionAmount,
                 spendAmount);
-
-            proposedOrderValues.Should().BeEquivalentTo(new AdjustedCheckValues(
-                spendAmount: 1131,
-                taxAmount: 74,
-                exemptionAmount: 0));
-
+            
+            // Assert
+            Assert.AreEqual(expectedProposedOrderValues.ExemptionAmount, proposedOrderValues.ExemptionAmount);
+            Assert.AreEqual(expectedProposedOrderValues.SpendAmount, proposedOrderValues.SpendAmount);
+            Assert.AreEqual(expectedProposedOrderValues.TaxAmount, proposedOrderValues.TaxAmount);
+             
+            // Arrange
             // apply discount(s)
             int availableDiscountAmount = 0;
 
             pointOfSale.ApplyDiscount(availableDiscountAmount);
 
+            var expectedCompletedOrderValues = new AdjustedCheckValues(
+                spendAmount: 1131, taxAmount: 74, exemptionAmount: 0);
+            
+            // Act
             // prepare Completed Order call
             AdjustedCheckValues completedOrderValues = ProposedOrderCalculator.CalculateCompleteOrderValues(
                 pointOfSale.TotalOutstandingAmount,
@@ -47,10 +56,10 @@ namespace LevelUp.Pos.ProposedOrders.Tests
                 spendAmount,
                 availableDiscountAmount);
 
-            completedOrderValues.Should().BeEquivalentTo(new AdjustedCheckValues(
-                spendAmount: 1131,
-                taxAmount: 74,
-                exemptionAmount: 0));
+            // Assert
+            Assert.AreEqual(expectedCompletedOrderValues.ExemptionAmount, completedOrderValues.ExemptionAmount);
+            Assert.AreEqual(expectedCompletedOrderValues.SpendAmount, completedOrderValues.SpendAmount);
+            Assert.AreEqual(expectedCompletedOrderValues.TaxAmount, completedOrderValues.TaxAmount);
         }
     }
 }

--- a/LevelUp.Pos.ProposedOrders.Tests/SplitTenderTests.cs
+++ b/LevelUp.Pos.ProposedOrders.Tests/SplitTenderTests.cs
@@ -18,16 +18,15 @@
 #endregion
 
 using System;
-using FluentAssertions;
 using LevelUp.Pos.ProposedOrders.Tests.Mocks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NUnit.Framework;
 
 namespace LevelUp.Pos.ProposedOrders.Tests
 {
-    [TestClass]
+    [TestFixture]
     public class SplitTenderTests
     {
-        [TestMethod]
+        [Test]
         public void SplitTenderExample_LevelUp_Then_Cash()
         {
             // Split tender example: partial payment to LevelUp ($10) and remaining balance tendered to cash.
@@ -45,7 +44,7 @@ namespace LevelUp.Pos.ProposedOrders.Tests
             int expectedTaxAmount = 0;
             int expectedSpendAmount = 1000;
             int expectedExemptionAmount = 0;
-            AdjustedCheckValues expectedProposedOderValues =
+            AdjustedCheckValues expectedProposedOrderValues =
                 new AdjustedCheckValues(expectedSpendAmount, expectedTaxAmount, expectedExemptionAmount);
 
             AdjustedCheckValues proposedOrderValues = ProposedOrderCalculator.CalculateCreateProposedOrderValues(
@@ -54,9 +53,9 @@ namespace LevelUp.Pos.ProposedOrders.Tests
                 exemptionAmount,
                 spendAmount);
 
-            proposedOrderValues.Should().BeEquivalentTo(expectedProposedOderValues,
-                $"Expected: {expectedProposedOderValues}" + Environment.NewLine +
-                $"Actual: {proposedOrderValues}");
+            Assert.AreEqual(expectedProposedOrderValues.ExemptionAmount, proposedOrderValues.ExemptionAmount);
+            Assert.AreEqual(expectedProposedOrderValues.SpendAmount, proposedOrderValues.SpendAmount);
+            Assert.AreEqual(expectedProposedOrderValues.TaxAmount, proposedOrderValues.TaxAmount);
 
             // available discount amount $1
             int availableDiscountAmount = 100;
@@ -79,12 +78,12 @@ namespace LevelUp.Pos.ProposedOrders.Tests
                 spendAmount,
                 availableDiscountAmount);
 
-            completedOrderValues.Should().BeEquivalentTo(expectedCompletedOrderValues,
-                $"Expected: {expectedCompletedOrderValues}" + Environment.NewLine +
-                $"Actual: {completedOrderValues}");
+            Assert.AreEqual(expectedProposedOrderValues.ExemptionAmount, completedOrderValues.ExemptionAmount);
+            Assert.AreEqual(expectedProposedOrderValues.SpendAmount, completedOrderValues.SpendAmount);
+            Assert.AreEqual(expectedProposedOrderValues.TaxAmount, completedOrderValues.TaxAmount);
         }
 
-        [TestMethod]
+        [Test]
         public void SplitTenderExample_Cash_Then_LevelUp()
         {
             // Split tender example: partial payment to cash ($10) and remaining balance tendered to LevelUp.
@@ -109,7 +108,7 @@ namespace LevelUp.Pos.ProposedOrders.Tests
             int expectedTaxAmount = 200;
             int expectedSpendAmount = 1200;
             int expectedExemptionAmount = 0;
-            AdjustedCheckValues expectedProposedOderValues =
+            AdjustedCheckValues expectedProposedOrderValues =
                 new AdjustedCheckValues(expectedSpendAmount, expectedTaxAmount, expectedExemptionAmount);
 
             AdjustedCheckValues proposedOrderValues = ProposedOrderCalculator.CalculateCreateProposedOrderValues(
@@ -118,9 +117,9 @@ namespace LevelUp.Pos.ProposedOrders.Tests
                 exemptionAmount,
                 spendAmount);
 
-            proposedOrderValues.Should().BeEquivalentTo(expectedProposedOderValues,
-                $"Expected: {expectedProposedOderValues}" + Environment.NewLine +
-                $"Actual: {proposedOrderValues}");
+            Assert.AreEqual(expectedProposedOrderValues.ExemptionAmount, proposedOrderValues.ExemptionAmount);
+            Assert.AreEqual(expectedProposedOrderValues.SpendAmount, proposedOrderValues.SpendAmount);
+            Assert.AreEqual(expectedProposedOrderValues.TaxAmount, proposedOrderValues.TaxAmount);
 
             // available discount amount $1
             int availableDiscountAmount = 100;
@@ -144,13 +143,12 @@ namespace LevelUp.Pos.ProposedOrders.Tests
                 exemptionAmount,
                 spendAmount,
                 availableDiscountAmount);
-
-            completedOrderValues.Should().BeEquivalentTo(expectedCompletedOrderValues,
-                $"Expected: {expectedCompletedOrderValues}" + Environment.NewLine +
-                $"Actual: {completedOrderValues}");
+            Assert.AreEqual(expectedCompletedOrderValues.ExemptionAmount, completedOrderValues.ExemptionAmount);
+            Assert.AreEqual(expectedCompletedOrderValues.SpendAmount, completedOrderValues.SpendAmount);
+            Assert.AreEqual(expectedCompletedOrderValues.TaxAmount, completedOrderValues.TaxAmount);
         }
        
-        [TestMethod]
+        [Test]
         public void SplitTenderExample_NoChangeInSpendOrTax_AfterLevelUpPaidFirst()
         {
             // $9.90 is owed, $0.90 of that is tax. $3.00 of that is tobacco/alcohol, and the customer wants to pay
@@ -171,10 +169,10 @@ namespace LevelUp.Pos.ProposedOrders.Tests
                 check.TotalTaxAmount,
                 exemptionAmount,
                 spendAmount);
-
-            proposedOrderValues.Should().BeEquivalentTo(expectedProposedOrderValues,
-                $"Expected: {expectedProposedOrderValues}" + Environment.NewLine +
-                $"Actual: {proposedOrderValues}");
+            
+            Assert.AreEqual(expectedProposedOrderValues.ExemptionAmount, proposedOrderValues.ExemptionAmount);
+            Assert.AreEqual(expectedProposedOrderValues.SpendAmount, proposedOrderValues.SpendAmount);
+            Assert.AreEqual(expectedProposedOrderValues.TaxAmount, proposedOrderValues.TaxAmount);
 
             // available discount amount $1
             int availableDiscountAmount = 100;
@@ -200,9 +198,9 @@ namespace LevelUp.Pos.ProposedOrders.Tests
                 spendAmount,
                 availableDiscountAmount);
 
-            completedOrderValues.Should().BeEquivalentTo(expectedCompletedOrderValues,
-                $"Expected: {expectedCompletedOrderValues}" + Environment.NewLine +
-                $"Actual: {completedOrderValues}");
+            Assert.AreEqual(expectedProposedOrderValues.ExemptionAmount, completedOrderValues.ExemptionAmount);
+            Assert.AreEqual(expectedProposedOrderValues.SpendAmount, completedOrderValues.SpendAmount);
+            Assert.AreEqual(expectedProposedOrderValues.TaxAmount, completedOrderValues.TaxAmount);
         }
         
         /// <summary>
@@ -212,7 +210,7 @@ namespace LevelUp.Pos.ProposedOrders.Tests
         /// <remarks>
         /// In this example, the second payment will still be responsible for some tax.
         /// </remarks>
-        [TestMethod]
+        [Test]
         public void SplitTenderExample_SpendAndTaxAreAdjusted_WhenLevelUpDiscountApplied()
         {
             // $22.00 is owed, $2.00 of that is tax. $0.00 of that is tobacco/alcohol, and the customer wants to pay
@@ -237,9 +235,9 @@ namespace LevelUp.Pos.ProposedOrders.Tests
                 exemptionAmount,
                 spendAmount);
 
-            proposedOrderValues.Should().BeEquivalentTo(expectedProposedOrderValues,
-                $"Expected: {expectedProposedOrderValues}" + Environment.NewLine +
-                $"Actual: {proposedOrderValues}");
+            Assert.AreEqual(expectedProposedOrderValues.ExemptionAmount, proposedOrderValues.ExemptionAmount);
+            Assert.AreEqual(expectedProposedOrderValues.SpendAmount, proposedOrderValues.SpendAmount);
+            Assert.AreEqual(expectedProposedOrderValues.TaxAmount, proposedOrderValues.TaxAmount);
 
             // available discount amount $10.00
             int availableDiscountAmount = 1000;
@@ -265,9 +263,10 @@ namespace LevelUp.Pos.ProposedOrders.Tests
                 spendAmount,
                 availableDiscountAmount);
 
-            completedOrderValues.Should().BeEquivalentTo(expectedCompletedOrderValues,
-                $"Expected: {expectedCompletedOrderValues}" + Environment.NewLine +
-                $"Actual: {completedOrderValues}");
+            Assert.AreEqual(expectedCompletedOrderValues.ExemptionAmount, completedOrderValues.ExemptionAmount);
+            Assert.AreEqual(expectedCompletedOrderValues.SpendAmount, completedOrderValues.SpendAmount);
+            Assert.AreEqual(expectedCompletedOrderValues.TaxAmount, completedOrderValues.TaxAmount);
+
         }
 
         /// <summary>
@@ -275,7 +274,7 @@ namespace LevelUp.Pos.ProposedOrders.Tests
         /// was found which could result in the tax_amount being incorrectly adjusted (increasing) on the 
         /// CalculateCompleteOrderValues(); call.
         /// </summary>
-        [TestMethod]
+        [Test]
         public void SplitTenderExample_NoChangeInSpendOrTax_WhenMostOfCheckIsDiscounted()
         {
             // $22.00 is owed, $2.00 of that is tax. $0.00 of that is tobacco/alcohol, and the customer wants to pay
@@ -297,9 +296,9 @@ namespace LevelUp.Pos.ProposedOrders.Tests
                 exemptionAmount,
                 spendAmount);
 
-            proposedOrderValues.Should().BeEquivalentTo(expectedProposedOrderValues,
-                $"Expected: {expectedProposedOrderValues}" + Environment.NewLine +
-                $"Actual: {proposedOrderValues}");
+            Assert.AreEqual(expectedProposedOrderValues.ExemptionAmount, proposedOrderValues.ExemptionAmount);
+            Assert.AreEqual(expectedProposedOrderValues.SpendAmount, proposedOrderValues.SpendAmount);
+            Assert.AreEqual(expectedProposedOrderValues.TaxAmount, proposedOrderValues.TaxAmount);
 
             // available discount amount $5.30
             int availableDiscountAmount = 530;
@@ -324,12 +323,12 @@ namespace LevelUp.Pos.ProposedOrders.Tests
                 spendAmount,
                 availableDiscountAmount);
 
-            completedOrderValues.Should().BeEquivalentTo(expectedCompletedOrderValues,
-                $"Expected: {expectedCompletedOrderValues}" + Environment.NewLine +
-                $"Actual: {completedOrderValues}");
+            Assert.AreEqual(expectedCompletedOrderValues.ExemptionAmount, completedOrderValues.ExemptionAmount);
+            Assert.AreEqual(expectedCompletedOrderValues.SpendAmount, completedOrderValues.SpendAmount);
+            Assert.AreEqual(expectedCompletedOrderValues.TaxAmount, completedOrderValues.TaxAmount);
         }
 
-        [TestMethod]
+        [Test]
         public void SplitTenderExample_OneCentPaid_WhenOneCentOwed()
         {
             // $0.02 is owed, $0.01 of that is tax. $0.00 of that is tobacco/alcohol, and the customer wants to pay
@@ -352,10 +351,10 @@ namespace LevelUp.Pos.ProposedOrders.Tests
                 pointOfSale.TotalTaxAmount,
                 exemptionAmount,
                 spendAmount);
-
-            proposedOrderValues.Should().BeEquivalentTo(expectedProposedOrderValues,
-                $"Expected: {expectedProposedOrderValues}" + Environment.NewLine +
-                $"Actual: {proposedOrderValues}");
+            
+            Assert.AreEqual(expectedProposedOrderValues.ExemptionAmount, proposedOrderValues.ExemptionAmount);
+            Assert.AreEqual(expectedProposedOrderValues.SpendAmount, proposedOrderValues.SpendAmount);
+            Assert.AreEqual(expectedProposedOrderValues.TaxAmount, proposedOrderValues.TaxAmount);
 
             // available discount amount $0.00
             int availableDiscountAmount = 0;
@@ -379,9 +378,9 @@ namespace LevelUp.Pos.ProposedOrders.Tests
                 spendAmount,
                 availableDiscountAmount);
 
-            completedOrderValues.Should().BeEquivalentTo(expectedCompletedOrderValues,
-                $"Expected: {expectedCompletedOrderValues}" + Environment.NewLine +
-                $"Actual: {completedOrderValues}");
+            Assert.AreEqual(expectedCompletedOrderValues.ExemptionAmount, completedOrderValues.ExemptionAmount);
+            Assert.AreEqual(expectedCompletedOrderValues.SpendAmount, completedOrderValues.SpendAmount);
+            Assert.AreEqual(expectedCompletedOrderValues.TaxAmount, completedOrderValues.TaxAmount);
         }
     }
 }

--- a/LevelUp.Pos.ProposedOrders.Tests/SplitTenderTests.cs
+++ b/LevelUp.Pos.ProposedOrders.Tests/SplitTenderTests.cs
@@ -16,8 +16,6 @@
 // </license>
 //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 #endregion
-
-using System;
 using LevelUp.Pos.ProposedOrders.Tests.Mocks;
 using NUnit.Framework;
 
@@ -29,6 +27,7 @@ namespace LevelUp.Pos.ProposedOrders.Tests
         [Test]
         public void SplitTenderExample_LevelUp_Then_Cash()
         {
+            // Arrange
             // Split tender example: partial payment to LevelUp ($10) and remaining balance tendered to cash.
             // Check details (prior to LevelUp Scan)
             //   Item subtotal: $20
@@ -47,16 +46,19 @@ namespace LevelUp.Pos.ProposedOrders.Tests
             AdjustedCheckValues expectedProposedOrderValues =
                 new AdjustedCheckValues(expectedSpendAmount, expectedTaxAmount, expectedExemptionAmount);
 
+            // Act
             AdjustedCheckValues proposedOrderValues = ProposedOrderCalculator.CalculateCreateProposedOrderValues(
                 check.TotalOutstandingAmount,
                 check.TotalTaxAmount,
                 exemptionAmount,
                 spendAmount);
-
+            
+            // Assert
             Assert.AreEqual(expectedProposedOrderValues.ExemptionAmount, proposedOrderValues.ExemptionAmount);
             Assert.AreEqual(expectedProposedOrderValues.SpendAmount, proposedOrderValues.SpendAmount);
             Assert.AreEqual(expectedProposedOrderValues.TaxAmount, proposedOrderValues.TaxAmount);
 
+            // Arrange
             // available discount amount $1
             int availableDiscountAmount = 100;
 
@@ -67,10 +69,11 @@ namespace LevelUp.Pos.ProposedOrders.Tests
             // tax amount unchanged
             // spend amount unchanged
             // exemption amount unchanged
-
+                       
             AdjustedCheckValues expectedCompletedOrderValues =
                 new AdjustedCheckValues(expectedSpendAmount, expectedTaxAmount, expectedExemptionAmount);
 
+            // Arrange
             AdjustedCheckValues completedOrderValues = ProposedOrderCalculator.CalculateCompleteOrderValues(
                 check.TotalOutstandingAmount,
                 check.TotalTaxAmount,
@@ -78,6 +81,7 @@ namespace LevelUp.Pos.ProposedOrders.Tests
                 spendAmount,
                 availableDiscountAmount);
 
+            // Assert
             Assert.AreEqual(expectedProposedOrderValues.ExemptionAmount, completedOrderValues.ExemptionAmount);
             Assert.AreEqual(expectedProposedOrderValues.SpendAmount, completedOrderValues.SpendAmount);
             Assert.AreEqual(expectedProposedOrderValues.TaxAmount, completedOrderValues.TaxAmount);

--- a/LevelUp.Pos.ProposedOrders.Tests/SplitTenderTests.cs
+++ b/LevelUp.Pos.ProposedOrders.Tests/SplitTenderTests.cs
@@ -73,7 +73,6 @@ namespace LevelUp.Pos.ProposedOrders.Tests
             AdjustedCheckValues expectedCompletedOrderValues =
                 new AdjustedCheckValues(expectedSpendAmount, expectedTaxAmount, expectedExemptionAmount);
 
-            // Arrange
             AdjustedCheckValues completedOrderValues = ProposedOrderCalculator.CalculateCompleteOrderValues(
                 check.TotalOutstandingAmount,
                 check.TotalTaxAmount,

--- a/LevelUp.Pos.ProposedOrders.Tests/UpdateExemptionAmountTests.cs
+++ b/LevelUp.Pos.ProposedOrders.Tests/UpdateExemptionAmountTests.cs
@@ -16,340 +16,186 @@
 // </license>
 //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 #endregion
-
-using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NUnit.Framework;
 
 namespace LevelUp.Pos.ProposedOrders.Tests
 {
-    [TestClass]
+    [TestFixture]
     public class UpdateExemptionAmountTests
     {
-        #region Partial Payments
-
-        [TestClass]
-        public class PaidInFull
+        // Too much is exempt
+        [Test]
+        [TestCase(1200, 900)] // Significantly over total
+        [TestCase(1050, 900)] // Slightly over total
+        public void CalculateOrderValues_WhenExemptAmountIsMoreThanTotal_ReturnsTotalAsExemptAmount(
+            int exemptionAmount, int expectedExemptionAmount)
         {
-            // Too much is exempt
-            [TestMethod]
-            public void UpdateExemption_WhenProposedOrderRequestIs_TooMuchIsExempt_MoreThanTotal()
-            {
-                int outstandingTotalOnCheck = 1000;
-                int taxAmount = 100;
-                int exemptionAmount = 1200;
-                int amountCustomerIsPaying = 1000;
+            // Arrange
+            int outstandingTotalOnCheck = 1000;
+            int taxAmount = 100;
+            int amountCustomerIsPaying = 1000;
 
-                ProposedOrderCalculator.CalculateOrderValues(outstandingTotalOnCheck, taxAmount, exemptionAmount, amountCustomerIsPaying)
-                    .ExemptionAmount.Should()
-                    .Be(900);
-            }
+            // Act
+            var result = ProposedOrderCalculator.CalculateOrderValues(
+                outstandingTotalOnCheck, taxAmount, exemptionAmount, amountCustomerIsPaying).ExemptionAmount;
 
-            [TestMethod]
-            public void UpdateExemption_WhenProposedOrderRequestIs_TooMuchIsExempt_LessThanTotal()
-            {
-                int outstandingTotalOnCheck = 1000;
-                int taxAmount = 100;
-                int exemptionAmount = 1050;
-                int amountCustomerIsPaying = 1000;
-
-                ProposedOrderCalculator.CalculateOrderValues(outstandingTotalOnCheck, taxAmount, exemptionAmount, amountCustomerIsPaying)
-                    .ExemptionAmount.Should()
-                    .Be(900);
-            }
-
-            // Order is fully exempt
-            [TestMethod]
-            public void UpdateExemption_WhenProposedOrderRequestIs_FullyExempt()
-            {
-                int outstandingTotalOnCheck = 1000;
-                int taxAmount = 100;
-                int exemptionAmount = 1000;
-                int amountCustomerIsPaying = 1000;
-
-                ProposedOrderCalculator.CalculateOrderValues(outstandingTotalOnCheck, taxAmount, exemptionAmount, amountCustomerIsPaying)
-                    .ExemptionAmount.Should()
-                    .Be(900);
-            }
-
-            // Order not exempt at all
-            [TestMethod]
-            public void UpdateExemption_WhenProposedOrderRequestIs_FullyNotExempt()
-            {
-                int outstandingTotalOnCheck = 1000;
-                int taxAmount = 100;
-                int exemptionAmount = 0;
-                int amountCustomerIsPaying = 1000;
-
-                ProposedOrderCalculator.CalculateOrderValues(outstandingTotalOnCheck, taxAmount, exemptionAmount, amountCustomerIsPaying)
-                    .ExemptionAmount.Should()
-                    .Be(0);
-            }
-
-            // Some of the order is exempt
-            [TestMethod]
-            public void UpdateExemption_WhenProposedOrderRequestIs_PartiallyExempt_SmallExemption()
-            {
-                int outstandingTotalOnCheck = 1000;
-                int taxAmount = 100;
-                int exemptionAmount = 100;
-                int amountCustomerIsPaying = 1000;
-
-                ProposedOrderCalculator.CalculateOrderValues(outstandingTotalOnCheck, taxAmount, exemptionAmount, amountCustomerIsPaying)
-                    .ExemptionAmount.Should()
-                    .Be(100);
-            }
-
-            // Most of the order is exempt
-            [TestMethod]
-            public void UpdateExemption_WhenProposedOrderRequestIs_MostlyExempt_LessThanSubtotal()
-            {
-                int outstandingTotalOnCheck = 1000;
-                int taxAmount = 100;
-                int exemptionAmount = 899;
-                int amountCustomerIsPaying = 1000;
-
-                ProposedOrderCalculator.CalculateOrderValues(outstandingTotalOnCheck, taxAmount, exemptionAmount, amountCustomerIsPaying)
-                    .ExemptionAmount.Should()
-                    .Be(899);
-            }
-
-            [TestMethod]
-            public void UpdateExemption_WhenProposedOrderRequestIs_MostlyExempt_EqualToSubtotal()
-            {
-                int outstandingTotalOnCheck = 1000;
-                int taxAmount = 100;
-                int exemptionAmount = 900;
-                int amountCustomerIsPaying = 1000;
-
-                ProposedOrderCalculator.CalculateOrderValues(outstandingTotalOnCheck, taxAmount, exemptionAmount, amountCustomerIsPaying)
-                    .ExemptionAmount.Should()
-                    .Be(900);
-            }
-
-            [TestMethod]
-            public void UpdateExemption_WhenProposedOrderRequestIs_MostlyExempt_GreaterThanSubtotal()
-            {
-                int outstandingTotalOnCheck = 1000;
-                int taxAmount = 100;
-                int exemptionAmount = 901;
-                int amountCustomerIsPaying = 1000;
-
-                ProposedOrderCalculator.CalculateOrderValues(outstandingTotalOnCheck, taxAmount, exemptionAmount, amountCustomerIsPaying)
-                    .ExemptionAmount.Should()
-                    .Be(900);
-            }
+            // Assert
+            Assert.AreEqual(expectedExemptionAmount, result);
         }
 
-        #endregion
-
-        #region Partial Payments
-
-        [TestClass]
-        public class PartialPayments
+        // Order is fully exempt
+        [Test]
+        public void CalculateOrderValues_WhenProposedOrderRequestIsFullyExempt_ReturnsPaymentAmountMinusTax()
         {
-            // Too much is exempt
-            [TestMethod]
-            public void UpdateExemption_WhenProposedOrderRequestIs_TooMuchIsExempt_MoreThanTotal()
-            {
-                int outstandingTotalOnCheck = 1000;
-                int taxAmount = 100;
-                int exemptionAmount = 1200;
-                int amountCustomerIsPaying = 500;
+            int outstandingTotalOnCheck = 1000;
+            int taxAmount = 100;
+            int exemptionAmount = 1000;
+            int amountCustomerIsPaying = 1000;
 
-                ProposedOrderCalculator.CalculateOrderValues(outstandingTotalOnCheck, taxAmount, exemptionAmount, amountCustomerIsPaying)
-                    .ExemptionAmount.Should()
-                    .Be(500);
-            }
+            var result = ProposedOrderCalculator.CalculateOrderValues(
+                outstandingTotalOnCheck, taxAmount, exemptionAmount, amountCustomerIsPaying).ExemptionAmount;
 
-            [TestMethod]
-            public void UpdateExemption_WhenProposedOrderRequestIs_TooMuchIsExempt_LessThanTotal()
-            {
-                int outstandingTotalOnCheck = 1000;
-                int taxAmount = 100;
-                int exemptionAmount = 1050;
-                int amountCustomerIsPaying = 500;
-
-                ProposedOrderCalculator.CalculateOrderValues(outstandingTotalOnCheck, taxAmount, exemptionAmount, amountCustomerIsPaying)
-                    .ExemptionAmount.Should()
-                    .Be(500);
-            }
-
-            // Order is fully exempt
-            [TestMethod]
-            public void UpdateExemption_WhenProposedOrderRequestIs_FullyExempt()
-            {
-                int outstandingTotalOnCheck = 1000;
-                int taxAmount = 100;
-                int exemptionAmount = 1000;
-                int amountCustomerIsPaying = 500;
-
-                ProposedOrderCalculator.CalculateOrderValues(outstandingTotalOnCheck, taxAmount, exemptionAmount, amountCustomerIsPaying)
-                    .ExemptionAmount.Should()
-                    .Be(500);
-            }
-
-            // Order not exempt at all
-            [TestMethod]
-            public void UpdateExemption_WhenProposedOrderRequestIs_FullyNotExempt()
-            {
-                int outstandingTotalOnCheck = 1000;
-                int taxAmount = 100;
-                int exemptionAmount = 0;
-                int amountCustomerIsPaying = 500;
-
-                ProposedOrderCalculator.CalculateOrderValues(outstandingTotalOnCheck, taxAmount, exemptionAmount, amountCustomerIsPaying)
-                    .ExemptionAmount.Should()
-                    .Be(0);
-            }
-
-            // Some of the order is exempt
-            [TestMethod]
-            public void UpdateExemption_WhenProposedOrderRequestIs_PartiallyExempt_SmallExemption()
-            {
-                int outstandingTotalOnCheck = 1000;
-                int taxAmount = 100;
-                int exemptionAmount = 100;
-                int amountCustomerIsPaying = 500;
-
-                ProposedOrderCalculator.CalculateOrderValues(outstandingTotalOnCheck, taxAmount, exemptionAmount, amountCustomerIsPaying)
-                    .ExemptionAmount.Should()
-                    .Be(0);
-            }
-
-            // Most of the order is exempt
-            [TestMethod]
-            public void UpdateExemption_WhenProposedOrderRequestIs_MostlyExempt_LessThan_CustomerPayment()
-            {
-                int outstandingTotalOnCheck = 1000;
-                int taxAmount = 100;
-                int exemptionAmount = 499;
-                int amountCustomerIsPaying = 500;
-
-                // of the $9.00 subtotal, only $4.99 is exempt; $9.00 - $4.99 = $4.01 can be paid before claiming responsibility for exemption amounts
-                ProposedOrderCalculator.CalculateOrderValues(outstandingTotalOnCheck, taxAmount, exemptionAmount, amountCustomerIsPaying)
-                    .ExemptionAmount.Should()
-                    .Be(99);
-            }
-
-            [TestMethod]
-            public void UpdateExemption_WhenProposedOrderRequestIs_MostlyExempt_EqualTo_CustomerPayment()
-            {
-                int outstandingTotalOnCheck = 1000;
-                int taxAmount = 100;
-                int exemptionAmount = 500;
-                int amountCustomerIsPaying = 500;
-
-                // of the $9.00 subtotal, only $5.00 is exempt; $9.00 - $5.00 = $4.00 can be paid before claiming responsibility for exemption amounts
-                ProposedOrderCalculator.CalculateOrderValues(outstandingTotalOnCheck, taxAmount, exemptionAmount, amountCustomerIsPaying)
-                    .ExemptionAmount.Should()
-                    .Be(100);
-            }
-
-            [TestMethod]
-            public void UpdateExemption_WhenProposedOrderRequestIs_MostlyExempt_GreaterThan_CustomerPayment()
-            {
-                int outstandingTotalOnCheck = 1000;
-                int taxAmount = 100;
-                int exemptionAmount = 501;
-                int amountCustomerIsPaying = 500;
-
-                // of the $9.00 subtotal, only $5.01 is exempt; $9.00 - $5.01 = $3.99 can be paid before claiming responsibility for exemption amounts
-                ProposedOrderCalculator.CalculateOrderValues(outstandingTotalOnCheck, taxAmount, exemptionAmount, amountCustomerIsPaying)
-                    .ExemptionAmount.Should()
-                    .Be(101);
-            }
-
-            // Most of the order is exempt
-            [TestMethod]
-            public void UpdateExemption_WhenProposedOrderRequestIs_MostlyExempt_LessThan_CustomerPayment_Fringe()
-            {
-                int outstandingTotalOnCheck = 1000;
-                int taxAmount = 100;
-                int exemptionAmount = 399;
-                int amountCustomerIsPaying = 500;
-
-                // of the $9.00 subtotal, only $4.99 is exempt; $9.00 - $3.99 = $5.01 can be paid before claiming responsibility for exemption amounts
-                ProposedOrderCalculator.CalculateOrderValues(outstandingTotalOnCheck, taxAmount, exemptionAmount, amountCustomerIsPaying)
-                    .ExemptionAmount.Should()
-                    .Be(0);
-            }
-
-            [TestMethod]
-            public void UpdateExemption_WhenProposedOrderRequestIs_MostlyExempt_EqualTo_CustomerPayment_Fringe()
-            {
-                int outstandingTotalOnCheck = 1000;
-                int taxAmount = 100;
-                int exemptionAmount = 400;
-                int amountCustomerIsPaying = 500;
-
-                // of the $9.00 subtotal, only $5.00 is exempt; $9.00 - $4.00 = $5.00 can be paid before claiming responsibility for exemption amounts
-                ProposedOrderCalculator.CalculateOrderValues(outstandingTotalOnCheck, taxAmount, exemptionAmount, amountCustomerIsPaying)
-                    .ExemptionAmount.Should()
-                    .Be(0);
-            }
-
-            [TestMethod]
-            public void UpdateExemption_WhenProposedOrderRequestIs_MostlyExempt_GreaterThan_CustomerPayment_Fringe()
-            {
-                int outstandingTotalOnCheck = 1000;
-                int taxAmount = 100;
-                int exemptionAmount = 401;
-                int amountCustomerIsPaying = 500;
-
-                // of the $9.00 subtotal, only $5.01 is exempt; $9.00 - $4.01 = $4.99 can be paid before claiming responsibility for exemption amounts
-                ProposedOrderCalculator.CalculateOrderValues(outstandingTotalOnCheck, taxAmount, exemptionAmount, amountCustomerIsPaying)
-                    .ExemptionAmount.Should()
-                    .Be(1);
-            }
+            Assert.AreEqual(900, result);
         }
 
-        [TestClass]
-        public class CherryPickedPartialPayments
+        // Order not exempt at all
+        [Test]
+        public void CalculateOrderValues_WhenProposedOrderRequestIsFullyNotExempt_ReturnsZero()
         {
-            // Most of the order is exempt
-            [TestMethod]
-            public void UpdateExemption_WhenProposedOrderRequestIs_MostlyExempt_LessThan_CustomerPayment_Fringe()
-            {
-                int outstandingTotalOnCheck = 600;
-                int taxAmount = 200;
-                int exemptionAmount = 399;
-                int amountCustomerIsPaying = 500;
+            int outstandingTotalOnCheck = 1000;
+            int taxAmount = 100;
+            int exemptionAmount = 0;
+            int amountCustomerIsPaying = 1000;
 
-                // of the $6.00 subtotal, only $4.99 is exempt; $6.00 - $3.99 = $2.01 can be paid before claiming responsibility for exemption amounts
-                ProposedOrderCalculator.CalculateOrderValues(outstandingTotalOnCheck, taxAmount, exemptionAmount, amountCustomerIsPaying)
-                    .ExemptionAmount.Should()
-                    .Be(399);
-            }
+            var result = ProposedOrderCalculator.CalculateOrderValues(
+                outstandingTotalOnCheck, taxAmount, exemptionAmount, amountCustomerIsPaying).ExemptionAmount;
 
-            [TestMethod]
-            public void UpdateExemption_WhenProposedOrderRequestIs_MostlyExempt_EqualTo_CustomerPayment_Fringe()
-            {
-                int outstandingTotalOnCheck = 600;
-                int taxAmount = 200;
-                int exemptionAmount = 400;
-                int amountCustomerIsPaying = 500;
-
-                // of the $6.00 subtotal, only $5.00 is exempt; $6.00 - $4.00 = $2.00 can be paid before claiming responsibility for exemption amounts
-                ProposedOrderCalculator.CalculateOrderValues(outstandingTotalOnCheck, taxAmount, exemptionAmount, amountCustomerIsPaying)
-                    .ExemptionAmount.Should()
-                    .Be(400);
-            }
-
-            [TestMethod]
-            public void UpdateExemption_WhenProposedOrderRequestIs_MostlyExempt_GreaterThan_CustomerPayment_Fringe()
-            {
-                int outstandingTotalOnCheck = 600;
-                int taxAmount = 200;
-                int exemptionAmount = 401;
-                int amountCustomerIsPaying = 500;
-
-                // of the $6.00 subtotal, only $5.01 is exempt; $6.00 - $4.01 = $1.99 can be paid before claiming responsibility for exemption amounts
-                ProposedOrderCalculator.CalculateOrderValues(outstandingTotalOnCheck, taxAmount, exemptionAmount, amountCustomerIsPaying)
-                    .ExemptionAmount.Should()
-                    .Be(400);
-            }
+            Assert.AreEqual(0, result);
         }
 
-        #endregion
+        // Order is partially exempt
+        [Test]
+        [TestCase(100, 100)] // Small Amount Exempt
+        [TestCase(899, 899)] // Mostly Exempt
+        [TestCase(900, 900)] // Equal to Pre-Tax Subtotal
+        [TestCase(901, 900)] // Greater than Pre-Tax Subtotal, less than total.
+        public void CalculateOrderValues_WhenProposedOrderRequestIsPartiallyExempt_ReturnsPartOfTotal(
+            int exemptionAmount, int expectedExemptionAmount)
+        {
+            int outstandingTotalOnCheck = 1000;
+            int taxAmount = 100;
+            int amountCustomerIsPaying = 1000;
+
+            var result = ProposedOrderCalculator.CalculateOrderValues(
+                outstandingTotalOnCheck, taxAmount, exemptionAmount, amountCustomerIsPaying).ExemptionAmount;
+
+            Assert.AreEqual(expectedExemptionAmount, result);
         }
+
+        // Too much is exempt
+        [Test]
+        [TestCase(1200, 500)] // More than Outstanding Total
+        [TestCase(1050, 500)] // More than Payment Amount
+        public void CalculateOrderValues_WhenExemptIsMoreThanSubtotalAndPaymentAmount_ReturnPaymentAmount(
+            int exemptionAmount, int expectedExemptionAmount)
+        {
+            int outstandingTotalOnCheck = 1000;
+            int taxAmount = 100;
+            int amountCustomerIsPaying = 500;
+
+            var result = ProposedOrderCalculator.CalculateOrderValues(
+                outstandingTotalOnCheck, taxAmount, exemptionAmount, amountCustomerIsPaying).ExemptionAmount;
+
+            Assert.AreEqual(expectedExemptionAmount, result);
+        }
+
+        // Order is fully exempt
+        [Test]
+        public void CalculateOrderValues_WhenProposedOrderRequestIsFullyExempt_ReturnsPaymentAmount()
+        {
+            int outstandingTotalOnCheck = 1000;
+            int taxAmount = 100;
+            int exemptionAmount = 1000;
+            int amountCustomerIsPaying = 500;
+
+            var result = ProposedOrderCalculator.CalculateOrderValues(
+                outstandingTotalOnCheck, taxAmount, exemptionAmount, amountCustomerIsPaying).ExemptionAmount;
+
+            Assert.AreEqual(500, result);
+        }
+
+        // Order not exempt at all
+        [Test]
+        public void CalculateOrderValues_WhenProposedOrderRequestIsFullyNotExemptWithPartialPayment_ReturnsZero()
+        {
+            int outstandingTotalOnCheck = 1000;
+            int taxAmount = 100;
+            int exemptionAmount = 0;
+            int amountCustomerIsPaying = 500;
+
+            var result = ProposedOrderCalculator.CalculateOrderValues(
+                outstandingTotalOnCheck, taxAmount, exemptionAmount, amountCustomerIsPaying).ExemptionAmount;
+
+            Assert.AreEqual(0, result);
+        }
+
+        // Some of the order is exempt
+        [Test]
+        [TestCase(100, 0)] // Small amount is exempt
+
+        // of the $9.00 subtotal, only $4.99 is exempt; $9.00 - $4.99 = $4.01 can be paid before claiming responsibility for exemption amounts
+        [TestCase(499, 99)] // Most is exempt
+
+        // of the $9.00 subtotal, only $5.00 is exempt; $9.00 - $5.00 = $4.00 can be paid before claiming responsibility for exemption amounts
+        [TestCase(500, 100)] // Most is exempt
+
+        // of the $9.00 subtotal, only $5.01 is exempt; $9.00 - $5.01 = $3.99 can be paid before claiming responsibility for exemption amounts
+        [TestCase(501, 101)] // Mostly exempt, more than customer payment.
+
+        // of the $9.00 subtotal, only $4.99 is exempt; $9.00 - $3.99 = $5.01 can be paid before claiming responsibility for exemption amounts
+        [TestCase(399, 0)]
+
+        // of the $9.00 subtotal, only $5.00 is exempt; $9.00 - $4.00 = $5.00 can be paid before claiming responsibility for exemption amounts
+        [TestCase(400, 0)]
+
+        // of the $9.00 subtotal, only $5.01 is exempt; $9.00 - $4.01 = $4.99 can be paid before claiming responsibility for exemption amounts
+        [TestCase(401, 1)]
+        public void CalculateOrderValues_WhenProposedOrderRequestIsPartiallyExempt(
+            int exemptionAmount, int expectedExemptionAmount)
+        {
+            int outstandingTotalOnCheck = 1000;
+            int taxAmount = 100;
+            int amountCustomerIsPaying = 500;
+
+            var result = ProposedOrderCalculator.CalculateOrderValues(
+                outstandingTotalOnCheck, taxAmount, exemptionAmount, amountCustomerIsPaying).ExemptionAmount;
+
+            Assert.AreEqual(expectedExemptionAmount, result);
+        }
+
+        [Test]
+        // of the $6.00 subtotal, only $4.99 is exempt; $6.00 - $3.99 = $2.01 can be paid before claiming responsibility for exemption amounts
+        [TestCase(399, 399)] // Mostly Exempt
+
+        // of the $6.00 subtotal, only $5.00 is exempt; $6.00 - $4.00 = $2.00 can be paid before claiming responsibility for exemption amounts
+        [TestCase(400, 400)]
+
+        // of the $6.00 subtotal, only $5.01 is exempt; $6.00 - $4.01 = $1.99 can be paid before claiming responsibility for exemption amounts
+        [TestCase(401, 400)]
+        public void UpdateExemption_WhenProposedOrderRequestIs_MostlyExempt_LessThan_CustomerPayment_Fringe(
+            int exemptionAmount, int expectedExemptionAmount)
+        {
+            // Arrange
+            int outstandingTotalOnCheck = 600;
+            int taxAmount = 200;
+            int amountCustomerIsPaying = 500;
+
+            // Act
+            var result = ProposedOrderCalculator.CalculateOrderValues(
+                outstandingTotalOnCheck, taxAmount, exemptionAmount, amountCustomerIsPaying).ExemptionAmount;
+
+            // Assert
+            Assert.AreEqual(expectedExemptionAmount, result);
+        }
+    }
 }

--- a/LevelUp.Pos.ProposedOrders.Tests/UpdateExemptionAmountTests.cs
+++ b/LevelUp.Pos.ProposedOrders.Tests/UpdateExemptionAmountTests.cs
@@ -26,7 +26,7 @@ namespace LevelUp.Pos.ProposedOrders.Tests
         // Too much is exempt
         [Test]
         [TestCase(1200, 900)] // Significantly over total
-        [TestCase(1050, 900)] // Slightly over total
+        [TestCase(1001, 900)] // Slightly over total
         public void CalculateOrderValues_WhenExemptAmountIsMoreThanTotal_ReturnsTotalAsExemptAmount(
             int exemptionAmount, int expectedExemptionAmount)
         {

--- a/LevelUp.Pos.ProposedOrders.Tests/UpdateExemptionAmountTests.cs
+++ b/LevelUp.Pos.ProposedOrders.Tests/UpdateExemptionAmountTests.cs
@@ -182,7 +182,7 @@ namespace LevelUp.Pos.ProposedOrders.Tests
 
         // of the $6.00 subtotal, only $5.01 is exempt; $6.00 - $4.01 = $1.99 can be paid before claiming responsibility for exemption amounts
         [TestCase(401, 400)]
-        public void UpdateExemption_WhenProposedOrderRequestIs_MostlyExempt_LessThan_CustomerPayment_Fringe(
+        public void CalculateOrderValues_WhenProposedOrderRequestIsMostlyExemptLessThanCustomerPayment(
             int exemptionAmount, int expectedExemptionAmount)
         {
             // Arrange

--- a/LevelUp.Pos.ProposedOrders.Tests/UpdateSpendAmountTests.cs
+++ b/LevelUp.Pos.ProposedOrders.Tests/UpdateSpendAmountTests.cs
@@ -16,61 +16,75 @@
 // </license>
 //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 #endregion
-
-using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NUnit.Framework;
 
 namespace LevelUp.Pos.ProposedOrders.Tests
 {
-    [TestClass]
+    [TestFixture]
     public class UpdateSpendAmountTests
     {
         // Payment requested > total due
-        [TestMethod]
+        [Test]
         public void UpdateSpend_WhenProposedOrderRequestIs_PayingTooMuch()
         {
+            // Arrange
             int outstandingTotalOnCheck = 1000;
             int amountCustomerIsPaying = 1200;
 
-            ProposedOrderCalculator.SanitizeData(outstandingTotalOnCheck, 0, 0, amountCustomerIsPaying)
-                .PaymentAmount.Should()
-                .Be(outstandingTotalOnCheck);
+            // Act
+            var result = ProposedOrderCalculator.SanitizeData(outstandingTotalOnCheck, 0, 0, amountCustomerIsPaying)
+                .PaymentAmount;
+
+            // Assert
+            Assert.AreEqual(outstandingTotalOnCheck, result);
         }
 
         // Paid In Full
-        [TestMethod]
+        [Test]
         public void UpdateSpend_WhenProposedOrderRequestIs_PaidInFull()
         {
+            // Arrange
             int outstandingTotalOnCheck = 1000;
             int amountCustomerIsPaying = 1000;
+            
+            // Act
+            var result = ProposedOrderCalculator.SanitizeData(outstandingTotalOnCheck, 0, 0, amountCustomerIsPaying)
+                .PaymentAmount;
 
-            ProposedOrderCalculator.SanitizeData(outstandingTotalOnCheck, 0, 0, amountCustomerIsPaying)
-                .PaymentAmount.Should()
-                .Be(amountCustomerIsPaying);
+            // Assert
+            Assert.AreEqual(amountCustomerIsPaying, result);
         }
 
         // Partial payment, payment requested < subtotal
-        [TestMethod]
+        [Test]
         public void UpdateSpend_WhenProposedOrderRequestIs_PartialPayment()
         {
+            // Arrange
             int outstandingTotalOnCheck = 1000;
             int amountCustomerIsPaying = 800;
 
-            ProposedOrderCalculator.SanitizeData(outstandingTotalOnCheck, 0, 0, amountCustomerIsPaying)
-                .PaymentAmount.Should()
-                .Be(amountCustomerIsPaying);
+            // Act
+            var result = ProposedOrderCalculator.SanitizeData(outstandingTotalOnCheck, 0, 0, amountCustomerIsPaying)
+                .PaymentAmount;
+
+            // Assert
+            Assert.AreEqual(amountCustomerIsPaying, result);
         }
 
         // Zero dollar payment
-        [TestMethod]
+        [Test]
         public void UpdateSpend_WhenProposedOrderRequestIs_PayingZero()
         {
+            // Arrange
             int outstandingTotalOnCheck = 1000;
             int amountCustomerIsPaying = 0;
 
-            ProposedOrderCalculator.SanitizeData(outstandingTotalOnCheck, 0, 0, amountCustomerIsPaying)
-                .PaymentAmount.Should()
-                .Be(amountCustomerIsPaying);
+            // Act
+            var result = ProposedOrderCalculator.SanitizeData(outstandingTotalOnCheck, 0, 0, amountCustomerIsPaying)
+                .PaymentAmount;
+
+            // Assert
+            Assert.AreEqual(amountCustomerIsPaying, result);
         }
     }
 }

--- a/LevelUp.Pos.ProposedOrders.Tests/UpdateTaxAmountTests.cs
+++ b/LevelUp.Pos.ProposedOrders.Tests/UpdateTaxAmountTests.cs
@@ -41,9 +41,9 @@ namespace LevelUp.Pos.ProposedOrders.Tests
         }
 
         [Test]
-        [TestCase(950, 50)]  // Partial payment, payment requested > subtotal
+        [TestCase(950, 50)] // Partial payment, payment requested > subtotal
         [TestCase(500, 0)] // Partial payment, payment requested < subtotal
-        [TestCase(1, 0)]
+        [TestCase(1, 0)] // small payment, not enough for tax
         [TestCase(0, 0)] // Zero dollar payment; this order would get rejected by platform
         public void CalculateOrderValues_WhenProposedOrderRequestIsNotPaidInFull_UpdatesTaxAmount(
             int amountCustomerIsPaying, int expectedTax)


### PR DESCRIPTION
**Ticket**:
https://levelup.atlassian.net/browse/INSTORE-625

**Test**:
Verified all of the tests had the same results pre and post-conversion.

**Notes**:
- So, coveralls percentages are slightly different (from 100% to 98%) . This is because we are no longer calling the `ToString()` override for `AdjustedCheckValues`. However - we weren't 'testing' this in the original MSTest version, we were just using them as part of our Assert statements. So effectively we still have not lost testing coverage %, the old number wasn't accurate. 
- I have consolidated the tests that are duplicates / edge cases of one another to use `TestCase`, instead of copying/pasting code. However, I've tried to keep test cases that have the same logic but different purposes separate. (For example, if a test has mostly identical logic, but one is testing an order that is fully exempt, and one is testing an order that is not exempt at all, I left them as two separate tests). 
- I'm more than willing to back the consolidated TestCases back into their own individual tests. 